### PR TITLE
feat: area_hover_col and tooltip

### DIFF
--- a/examples/sdl_opengl2_plot_example/Makefile
+++ b/examples/sdl_opengl2_plot_example/Makefile
@@ -4,7 +4,7 @@
 
 CXX = g++
 
-EXE = example_sdl_opengl2_plot.out
+EXE = plot.out
 SOURCES = main.cpp ../imgui_impl_sdl.cpp ../imgui_impl_opengl2.cpp
 SOURCES += ../../imgui.cpp ../../imgui_demo.cpp ../../imgui_draw.cpp
 OBJS = $(addsuffix .o, $(basename $(notdir $(SOURCES))))

--- a/examples/sdl_opengl2_plot_example/main.cpp
+++ b/examples/sdl_opengl2_plot_example/main.cpp
@@ -764,16 +764,19 @@ int main(int, char**)
 
             area_properties.area_fill_col = ImGui::ColorConvertFloat4ToU32(scales_color.Scale(0));
             // area_properties.hover_color = ImGui::ColorConvertFloat4ToU32(ImVec4(255.0f, 0.0f, 0.0f, 255.0f));
+            area_properties.tooltip = "series 1";
             Areas.SetProperties(area_properties);
             Areas.DrawArea(Figure, x_data, y_data1, n_data);
 
             area_properties.area_fill_col = ImGui::ColorConvertFloat4ToU32(scales_color.Scale(1));
             // area_properties.hover_color = ImGui::ColorConvertFloat4ToU32(ImVec4(255.0f, 0.0f, 0.0f, 255.0f));
+            area_properties.tooltip = "series 2";
             Areas.SetProperties(area_properties);
             Areas.DrawArea(Figure, x_data, y_data2, n_data);
 
             area_properties.area_fill_col = ImGui::ColorConvertFloat4ToU32(scales_color.Scale(2));
             // area_properties.hover_color = ImGui::ColorConvertFloat4ToU32(ImVec4(255.0f, 0.0f, 0.0f, 255.0f));
+            area_properties.tooltip = "series 3";
             Areas.SetProperties(area_properties);
             Areas.DrawArea(Figure, x_data, y_data3, n_data);
 
@@ -837,7 +840,7 @@ int main(int, char**)
 
             // Color scales
             ImGui::ImLinearScales<float, ImVec4> scales_color;
-            scales_color.SetDomain(0.0f, 2.0f);
+            scales_color.SetDomain(0.0f, 3.0f);
             scales_color.SetRange(ImVec4(255.0f, 0.0f, 0.0f, 255.0f), ImVec4(0.0f, 0.0f, 255.0f, 255.0f));
 
             // ImGui::SetNextWindowPos(ImVec2(0,0));
@@ -868,17 +871,20 @@ int main(int, char**)
             ImGui::ImArea<float, float> Areas;
 
             area_properties.area_fill_col = ImGui::ColorConvertFloat4ToU32(scales_color.Scale(0));
-            // area_properties.hover_color = ImGui::ColorConvertFloat4ToU32(ImVec4(255.0f, 0.0f, 0.0f, 255.0f));
+            area_properties.area_hover_col = ImGui::ColorConvertFloat4ToU32(scales_color.Scale(3));
+            area_properties.tooltip = "series 1";
             Areas.SetProperties(area_properties);
             Areas.DrawArea(Figure, x_data, y_data1, n_data, y_data_bottoms);
 
             area_properties.area_fill_col = ImGui::ColorConvertFloat4ToU32(scales_color.Scale(1));
-            // area_properties.hover_color = ImGui::ColorConvertFloat4ToU32(ImVec4(255.0f, 0.0f, 0.0f, 255.0f));
+            area_properties.area_hover_col = ImGui::ColorConvertFloat4ToU32(scales_color.Scale(3));
+            area_properties.tooltip = "series 2";
             Areas.SetProperties(area_properties);
             Areas.DrawArea(Figure, x_data, y_data2, n_data, y_data_bottoms);
 
             area_properties.area_fill_col = ImGui::ColorConvertFloat4ToU32(scales_color.Scale(2));
-            // area_properties.hover_color = ImGui::ColorConvertFloat4ToU32(ImVec4(255.0f, 0.0f, 0.0f, 255.0f));
+            area_properties.area_hover_col = ImGui::ColorConvertFloat4ToU32(scales_color.Scale(3));
+            area_properties.tooltip = "series 3";
             Areas.SetProperties(area_properties);
             Areas.DrawArea(Figure, x_data, y_data3, n_data, y_data_bottoms);
 

--- a/imgui_plot.h
+++ b/imgui_plot.h
@@ -10,7 +10,6 @@
 #include "imgui_internal.h"
 
 #include <iostream> //delete when finished debugging
-#include <vector>
 
 namespace ImGui
 {
@@ -1105,18 +1104,19 @@ namespace ImGui
             }
             float const * const y = y_data_bottoms ? y_data_bottoms : y_data;
 
-            std::vector<ImVec2> v;
+            ImVector<ImVec2> v;
+            v.reserve(n_data + 2);
 
             ImDrawList* dl = window->DrawList;
-            v.emplace_back(figure.GetScalesX()->Scale(x_data[0]), figure.GetScalesY()->Scale(y[0] - y_data[0]));
+            v.push_back(ImVec2(figure.GetScalesX()->Scale(x_data[0]), figure.GetScalesY()->Scale(y[0] - y_data[0])));
             dl->PathLineTo(v.back());
 
             for (size_t i = 0; i < n_data; ++i) {
-                v.emplace_back(figure.GetScalesX()->Scale(x_data[i]), figure.GetScalesY()->Scale(y[i]));
+                v.push_back(ImVec2(figure.GetScalesX()->Scale(x_data[i]), figure.GetScalesY()->Scale(y[i])));
                 dl->PathLineTo(v.back());
             }
 
-            v.emplace_back(figure.GetScalesX()->Scale(x_data[n_data-1]), figure.GetScalesY()->Scale(y[n_data-1] - y_data[n_data-1]));
+            v.push_back(ImVec2(figure.GetScalesX()->Scale(x_data[n_data-1]), figure.GetScalesY()->Scale(y[n_data-1] - y_data[n_data-1])));
             dl->PathLineTo(v.back());
 
             ImVec2 pointer(GImGui->IO.MousePos.x, GImGui->IO.MousePos.y);
@@ -1142,7 +1142,7 @@ namespace ImGui
     private:
         ImAreaProperties properties_;
 
-        bool is_inside_area(const ImVec2& P, const std::vector<ImVec2>& V) const
+        bool is_inside_area(const ImVec2& P, const ImVector<ImVec2>& V) const
         {
             size_t cn = 0; // the crossing number counter
             size_t n = V.size();

--- a/imgui_plot.h
+++ b/imgui_plot.h
@@ -30,6 +30,8 @@ namespace ImGui
     // static inline float*    ImQuaBSerp(float a, float b, float t, int n, bool closed = false);                        //TODO [DM] Quantized BSpline sampler
     // static inline ImVec4*   ImQuaBSerp(const ImVec4& a, const ImVec4& b, const ImVec4& t, int n, bool closed = false);                        //TODO [DM] Quantized BSpline sampler used for colors
 
+    bool is_inside_area(const ImVec2& P, const ImVector<ImVec2>& V);
+
     // ## Scales
     template<typename Ta, typename Tb>
     class ImScales
@@ -1141,31 +1143,31 @@ namespace ImGui
 
     private:
         ImAreaProperties properties_;
-
-        bool is_inside_area(const ImVec2& P, const ImVector<ImVec2>& V) const
-        {
-            size_t cn = 0; // the crossing number counter
-            size_t n = V.size();
-
-            if (n < 3) return false;
-
-            size_t i = 0;
-            size_t j = 1;
-
-            while (i < n) {
-                if (((V[i].y <= P.y) && (V[j].y > P.y)) || ((V[i].y > P.y) && (V[j].y <= P.y))) {
-                    float vt = (float)(P.y - V[i].y) / (V[j].y - V[i].y);
-                    if (P.x < V[i].x + vt * (V[j].x - V[i].x)) { // P.x < intersect
-                        ++cn; // a valid crossing of y=P.y right of P.x
-                    }
-                }
-                ++i;
-                j = (i + 1) % n;
-            }
-
-            return cn % 2 != 0; // false if even (out), and true if odd (in)
-        }
     };
+
+    bool is_inside_area(const ImVec2& P, const ImVector<ImVec2>& V)
+    {
+        size_t cn = 0; // the crossing number counter
+        size_t n = V.size();
+
+        if (n < 3) return false;
+
+        size_t i = 0;
+        size_t j = 1;
+
+        while (i < n) {
+            if (((V[i].y <= P.y) && (V[j].y > P.y)) || ((V[i].y > P.y) && (V[j].y <= P.y))) {
+                float vt = (float)(P.y - V[i].y) / (V[j].y - V[i].y);
+                if (P.x < V[i].x + vt * (V[j].x - V[i].x)) { // P.x < intersect
+                    ++cn; // a valid crossing of y=P.y right of P.x
+                }
+            }
+            ++i;
+            j = (i + 1) % n;
+        }
+
+        return cn % 2 != 0; // false if even (out), and true if odd (in)
+    }
 
     // # High level plotting functions
 


### PR DESCRIPTION
Do you know a better way to see if the mouse pointer is within a certain closed path?

I searched for an algorithm and I found about the ray casting algorithm.
source (`cn_PnPoly`): http://geomalgorithms.com/a03-_inclusion.html

I cleaned it up a bit in our code.

In the case of non-stacked area plot, currently there is no way to check which "series" one is hovering... and multiple series could be affected by the change of area color. Like there is no concept of z-index.

What do you think of this approach?